### PR TITLE
Adicionar simulação de portas lógicas

### DIFF
--- a/src/EditorEnvironment.ts
+++ b/src/EditorEnvironment.ts
@@ -179,7 +179,7 @@ class EditorEnvironment {
     if (type) {
       switch (type) {
         case ComponentType.NODE:
-          signalEvents.removeVertex(this, componentId, type);
+          signalEvents.removeVertex(this, componentId);
           return this.nodeList.delete(componentId);
         case ComponentType.SLOT:
           return this.slotList.delete(componentId);
@@ -189,10 +189,10 @@ class EditorEnvironment {
         case ComponentType.TEXT:
           return this.textList.delete(componentId);
         case ComponentType.INPUT:
-          signalEvents.removeVertex(this, componentId, type);
+          signalEvents.removeVertex(this, componentId);
           return this.inputList.delete(componentId);
         case ComponentType.OUTPUT:
-          signalEvents.removeVertex(this, componentId, type);
+          signalEvents.removeVertex(this, componentId);
           return this.outputList.delete(componentId);
         default:
           return false;

--- a/src/EditorEnvironment.ts
+++ b/src/EditorEnvironment.ts
@@ -115,7 +115,7 @@ class EditorEnvironment {
       case ComponentType.NODE:
         this.nodeList.set(this._nextComponentId, component as NodeComponent);
         signalEvents.addVertex(
-          this._signalGraph,
+          this,
           this._nextComponentId,
           undefined,
           signalEvents.convertToSignalFromList(
@@ -140,7 +140,7 @@ class EditorEnvironment {
       case ComponentType.INPUT:
         this.inputList.set(this._nextComponentId, component as InputComponent);
         signalEvents.addVertex(
-          this._signalGraph,
+          this,
           this._nextComponentId,
           undefined,
           signalEvents.convertToSignalFromList(
@@ -156,7 +156,7 @@ class EditorEnvironment {
           component as OutputComponent
         );
         signalEvents.addVertex(
-          this._signalGraph,
+          this,
           this._nextComponentId,
           undefined,
           signalEvents.convertToSignalFromList(

--- a/src/functions/Connection/connectionEvents.ts
+++ b/src/functions/Connection/connectionEvents.ts
@@ -68,7 +68,8 @@ export default {
       this.editingLineId === -1 ||
       nodeEvents.editingNode ||
       inputEvents.editingInput ||
-      outputEvents.editingOutput
+      outputEvents.editingOutput ||
+      !Editor.editorEnv.connections.has(this.editingLineId)
     )
       return false;
 

--- a/src/functions/Connection/connectionEvents.ts
+++ b/src/functions/Connection/connectionEvents.ts
@@ -69,7 +69,7 @@ export default {
       nodeEvents.editingNode ||
       inputEvents.editingInput ||
       outputEvents.editingOutput ||
-      !Editor.editorEnv.connections.has(this.editingLineId)
+      !editorEnv.connections.has(this.editingLineId)
     )
       return false;
 

--- a/src/functions/Signal/signalEvents.ts
+++ b/src/functions/Signal/signalEvents.ts
@@ -64,7 +64,7 @@ export default {
     } else {
       this.addVertex(editorEnv, endNodeId, false, [startNodeId]);
     }
-    signalUpdate.updateGraph(editorEnv);
+    signalUpdate.updateGraphPartial(editorEnv, startNodeId);
   },
   removeEdge(
     editorEnv: EditorEnvironment,

--- a/src/functions/Signal/signalEvents.ts
+++ b/src/functions/Signal/signalEvents.ts
@@ -2,7 +2,7 @@ import EditorEnvironment from '../../EditorEnvironment';
 import ConnectionComponent from '../../components/ConnectionComponent';
 import SlotComponent from '../../components/SlotComponent';
 import ComponentType, {SignalGraph} from '../../types/types';
-// import signalUpdate from './signalUpdate';
+import signalUpdate from './signalUpdate';
 
 export default {
   addVertex(
@@ -13,7 +13,7 @@ export default {
   ): void {
     if (!signalGraph.has(nodeId)) {
       signalGraph.set(nodeId, {state, signalFrom});
-      // signalUpdate.updateGraph();
+      signalUpdate.updateGraph();
     }
   },
   removeVertex(
@@ -25,19 +25,13 @@ export default {
       let slots: Array<SlotComponent> = [];
       switch (componentType) {
         case ComponentType.INPUT:
-          slots =
-            editorEnv.inputs.get(nodeId)!.slotComponents === undefined
-              ? []
-              : editorEnv.inputs.get(nodeId)!.slotComponents!;
+          slots = editorEnv.inputs.get(nodeId)!.slotComponents;
           break;
         case ComponentType.NODE:
           slots = editorEnv.nodes.get(nodeId)!.slotComponents;
           break;
         case ComponentType.OUTPUT:
-          slots =
-            editorEnv.inputs.get(nodeId)!.slotComponents === undefined
-              ? []
-              : editorEnv.inputs.get(nodeId)!.slotComponents!;
+          slots = editorEnv.outputs.get(nodeId)!.slotComponents;
       }
       for (let i = 0; i < slots.length; i++) {
         if (slots[i].inSlot) {
@@ -49,7 +43,7 @@ export default {
         }
       }
       editorEnv.signalGraph.delete(nodeId);
-      // signalUpdate.updateGraph();
+      signalUpdate.updateGraph();
     }
   },
   addEdge(editorEnv: EditorEnvironment, connection: ConnectionComponent): void {
@@ -74,7 +68,7 @@ export default {
     } else {
       this.addVertex(editorEnv.signalGraph, endNodeId, false, [startNodeId]);
     }
-    // signalUpdate.updateGraph();
+    signalUpdate.updateGraph();
   },
   removeEdge(
     editorEnv: EditorEnvironment,
@@ -92,7 +86,7 @@ export default {
       if (index !== -1)
         editorEnv.signalGraph.get(endNode.id)!.signalFrom.splice(index, 1);
     }
-    // signalUpdate.updateGraph();
+    signalUpdate.updateGraph();
   },
   getVertexState(signalGraph: SignalGraph, nodeId: number): boolean {
     return signalGraph.get(nodeId)?.state ?? false;
@@ -104,7 +98,7 @@ export default {
   ): void {
     if (signalGraph.has(nodeId)) {
       signalGraph.get(nodeId)!.state = state;
-      // signalUpdate.updateGraphPartial();
+      signalUpdate.updateGraph();
     }
   },
   getVertexConnections(
@@ -126,19 +120,13 @@ export default {
       let slots: Array<SlotComponent> = [];
       switch (componentType) {
         case ComponentType.INPUT:
-          slots =
-            editorEnv.inputs.get(nodeId)?.slotComponents === undefined
-              ? []
-              : editorEnv.inputs.get(nodeId)!.slotComponents!;
+          slots = editorEnv.inputs.get(nodeId)!.slotComponents;
           break;
         case ComponentType.NODE:
           slots = editorEnv.nodes.get(nodeId)?.slotComponents ?? [];
           break;
         case ComponentType.OUTPUT:
-          slots =
-            editorEnv.inputs.get(nodeId)?.slotComponents === undefined
-              ? []
-              : editorEnv.inputs.get(nodeId)!.slotComponents!;
+          slots = editorEnv.inputs.get(nodeId)!.slotComponents;
       }
       for (let i = 0; i < slots.length; i++) {
         if (slots[i].inSlot) {

--- a/src/functions/Signal/signalEvents.ts
+++ b/src/functions/Signal/signalEvents.ts
@@ -98,7 +98,7 @@ export default {
   ): void {
     if (signalGraph.has(nodeId)) {
       signalGraph.get(nodeId)!.state = state;
-      signalUpdate.updateGraph();
+      signalUpdate.updateGraphPartial(nodeId);
     }
   },
   getVertexConnections(

--- a/src/functions/Signal/signalEvents.ts
+++ b/src/functions/Signal/signalEvents.ts
@@ -6,15 +6,15 @@ import signalUpdate from './signalUpdate';
 
 export default {
   addVertex(
-    signalGraph: SignalGraph,
+    editorEnv: EditorEnvironment,
     nodeId: number,
     state: boolean = false,
     signalFrom: Array<number> = [],
     signalTo: Array<number> = []
   ): void {
-    if (!signalGraph.has(nodeId)) {
-      signalGraph.set(nodeId, {state, signalFrom, signalTo});
-      signalUpdate.updateGraph();
+    if (!editorEnv.signalGraph.has(nodeId)) {
+      editorEnv.signalGraph.set(nodeId, {state, signalFrom, signalTo});
+      signalUpdate.updateGraph(editorEnv);
     }
   },
   removeVertex(editorEnv: EditorEnvironment, nodeId: number): void {
@@ -29,7 +29,7 @@ export default {
         }
       });
       editorEnv.signalGraph.delete(nodeId);
-      signalUpdate.updateGraph();
+      signalUpdate.updateGraph(editorEnv);
     }
   },
   addEdge(editorEnv: EditorEnvironment, connection: ConnectionComponent): void {
@@ -52,9 +52,7 @@ export default {
       )
         editorEnv.signalGraph.get(startNodeId)!.signalTo.push(endNodeId);
     } else {
-      this.addVertex(editorEnv.signalGraph, startNodeId, false, undefined, [
-        endNodeId,
-      ]);
+      this.addVertex(editorEnv, startNodeId, false, undefined, [endNodeId]);
     }
     if (editorEnv.signalGraph.has(endNodeId)) {
       if (
@@ -62,12 +60,11 @@ export default {
           .get(endNodeId)!
           .signalFrom.find(el => startNodeId === el) === undefined
       )
-        return;
-      editorEnv.signalGraph.get(endNodeId)!.signalFrom.push(startNodeId);
+        editorEnv.signalGraph.get(endNodeId)!.signalFrom.push(startNodeId);
     } else {
-      this.addVertex(editorEnv.signalGraph, endNodeId, false, [startNodeId]);
+      this.addVertex(editorEnv, endNodeId, false, [startNodeId]);
     }
-    signalUpdate.updateGraph();
+    signalUpdate.updateGraph(editorEnv);
   },
   removeEdge(
     editorEnv: EditorEnvironment,
@@ -92,7 +89,7 @@ export default {
       if (indexST !== -1)
         editorEnv.signalGraph.get(startNodeId)!.signalTo.splice(indexST, 1);
     }
-    signalUpdate.updateGraph();
+    signalUpdate.updateGraph(editorEnv);
   },
   getVertexState(signalGraph: SignalGraph, nodeId: number): boolean {
     return signalGraph.get(nodeId)?.state ?? false;
@@ -104,7 +101,6 @@ export default {
   ): void {
     if (signalGraph.has(nodeId)) {
       signalGraph.get(nodeId)!.state = state;
-      signalUpdate.updateGraphPartial(nodeId);
     }
   },
   getVertexConnections(
@@ -129,10 +125,10 @@ export default {
           slots = editorEnv.inputs.get(nodeId)!.slotComponents;
           break;
         case ComponentType.NODE:
-          slots = editorEnv.nodes.get(nodeId)?.slotComponents ?? [];
+          slots = editorEnv.nodes.get(nodeId)!.slotComponents;
           break;
         case ComponentType.OUTPUT:
-          slots = editorEnv.inputs.get(nodeId)!.slotComponents;
+          slots = editorEnv.outputs.get(nodeId)!.slotComponents;
       }
       for (let i = 0; i < slots.length; i++) {
         if (slots[i].inSlot) {

--- a/src/functions/Signal/signalUpdate.ts
+++ b/src/functions/Signal/signalUpdate.ts
@@ -20,23 +20,7 @@ export default {
         visited.add(stack[0]);
         const nodeObj = this.getNodeObject(stack[0]);
         if (nodeObj !== undefined) {
-          for (const slot of nodeObj.slotComponents) {
-            if (slot.inSlot) continue;
-            for (const connection of slot.slotConnections) {
-              if (connection.connectedTo.start) {
-                const slot = Editor.editorEnv.slots.get(
-                  connection.connectedTo.start.id
-                )!;
-                stack.push(slot.parent.id);
-              }
-              if (connection.connectedTo.end) {
-                const slot = Editor.editorEnv.slots.get(
-                  connection.connectedTo.end.id
-                )!;
-                stack.push(slot.parent.id);
-              }
-            }
-          }
+          stack.push(...Editor.editorEnv.signalGraph.get(stack[0])!.signalTo);
           if (
             stack[0] !== nodeId &&
             nodeObj.componentType !== ComponentType.INPUT

--- a/src/functions/Signal/signalUpdate.ts
+++ b/src/functions/Signal/signalUpdate.ts
@@ -6,7 +6,7 @@ import ComponentType, {SignalGraph, SignalGraphData} from '../../types/types';
 
 export default {
   updateGraph(editorEnv: EditorEnvironment): void {
-    const visited: Map<number, boolean> = new Map();
+    const visited: Set<number> = new Set();
     editorEnv.signalGraph.forEach((_node, key) => {
       this.updateVertexStatus(editorEnv, key, visited);
     });
@@ -39,11 +39,11 @@ export default {
   updateVertexStatus(
     editorEnv: EditorEnvironment,
     nodeId: number,
-    visited: Map<number, boolean>
+    visited: Set<number>
   ): void {
     if (visited.has(nodeId)) return;
+    visited.add(nodeId);
     const node = editorEnv.signalGraph.get(nodeId);
-    visited.set(nodeId, true);
     if (node === undefined) return;
     if (node.signalFrom.length < 1) return;
     for (let i = 0; i < node.signalFrom.length; i++)

--- a/src/functions/Signal/signalUpdate.ts
+++ b/src/functions/Signal/signalUpdate.ts
@@ -1,0 +1,39 @@
+import Editor from '../../Editor';
+import ComponentType from '../../types/types';
+
+export default {
+  updateGraph(): void {
+    const visited: Map<number, boolean> = new Map();
+    Editor.editorEnv.signalGraph.forEach((_node, key) => {
+      this.updateVertexStatus(key, visited);
+    });
+    visited.clear();
+  },
+  updateGraphPartial(): void {},
+  updateVertexStatus(nodeId: number, visited: Map<number, boolean>): void {
+    if (visited.has(nodeId)) return;
+    const node = Editor.editorEnv.signalGraph.get(nodeId);
+    visited.set(nodeId, true);
+    if (node !== undefined) {
+      if (node.signalFrom.length > 0)
+        for (let i = 0; i < node.signalFrom.length; i++)
+          this.updateVertexStatus(node.signalFrom[i], visited);
+      const nodeObj =
+        Editor.editorEnv.nodes.get(nodeId) ??
+        Editor.editorEnv.inputs.get(nodeId) ??
+        Editor.editorEnv.outputs.get(nodeId);
+      if (
+        nodeObj !== undefined &&
+        nodeObj.componentType !== ComponentType.INPUT
+      ) {
+        const op: (slotState: Array<boolean>) => boolean = nodeObj.nodeType.op;
+        const slotStatus: Array<boolean> = [];
+        for (let i = 0; i < node.signalFrom.length; i++)
+          slotStatus.push(
+            Editor.editorEnv.signalGraph.get(node.signalFrom[i])?.state ?? false
+          );
+        node.state = op(slotStatus);
+      }
+    }
+  },
+};

--- a/src/functions/Signal/signalUpdate.ts
+++ b/src/functions/Signal/signalUpdate.ts
@@ -1,5 +1,8 @@
 import Editor from '../../Editor';
-import ComponentType from '../../types/types';
+import InputComponent from '../../components/InputComponent';
+import NodeComponent from '../../components/NodeComponent';
+import OutputComponent from '../../components/OutputComponent';
+import ComponentType, {SignalGraphData} from '../../types/types';
 
 export default {
   updateGraph(): void {
@@ -9,31 +12,76 @@ export default {
     });
     visited.clear();
   },
-  updateGraphPartial(): void {},
+  updateGraphPartial(nodeId: number): void {
+    const visited: Set<number> = new Set();
+    const stack: Array<number> = [nodeId];
+    do {
+      if (!visited.has(stack[0])) {
+        visited.add(stack[0]);
+        const nodeObj = this.getNodeObject(stack[0]);
+        if (nodeObj !== undefined) {
+          for (const slot of nodeObj.slotComponents) {
+            if (slot.inSlot) continue;
+            for (const connection of slot.slotConnections) {
+              if (connection.connectedTo.start) {
+                const slot = Editor.editorEnv.slots.get(
+                  connection.connectedTo.start.id
+                )!;
+                stack.push(slot.parent.id);
+              }
+              if (connection.connectedTo.end) {
+                const slot = Editor.editorEnv.slots.get(
+                  connection.connectedTo.end.id
+                )!;
+                stack.push(slot.parent.id);
+              }
+            }
+          }
+          if (
+            stack[0] !== nodeId &&
+            nodeObj.componentType !== ComponentType.INPUT
+          ) {
+            this.computeState(
+              Editor.editorEnv.signalGraph.get(stack[0])!,
+              nodeObj
+            );
+          }
+        }
+      }
+      stack.shift();
+    } while (stack.length > 0);
+  },
   updateVertexStatus(nodeId: number, visited: Map<number, boolean>): void {
     if (visited.has(nodeId)) return;
     const node = Editor.editorEnv.signalGraph.get(nodeId);
     visited.set(nodeId, true);
-    if (node !== undefined) {
-      if (node.signalFrom.length > 0)
-        for (let i = 0; i < node.signalFrom.length; i++)
-          this.updateVertexStatus(node.signalFrom[i], visited);
-      const nodeObj =
-        Editor.editorEnv.nodes.get(nodeId) ??
-        Editor.editorEnv.inputs.get(nodeId) ??
-        Editor.editorEnv.outputs.get(nodeId);
-      if (
-        nodeObj !== undefined &&
-        nodeObj.componentType !== ComponentType.INPUT
-      ) {
-        const op: (slotState: Array<boolean>) => boolean = nodeObj.nodeType.op;
-        const slotStatus: Array<boolean> = [];
-        for (let i = 0; i < node.signalFrom.length; i++)
-          slotStatus.push(
-            Editor.editorEnv.signalGraph.get(node.signalFrom[i])?.state ?? false
-          );
-        node.state = op(slotStatus);
-      }
-    }
+    if (node === undefined) return;
+    if (node.signalFrom.length < 1) return;
+    for (let i = 0; i < node.signalFrom.length; i++)
+      this.updateVertexStatus(node.signalFrom[i], visited);
+    const nodeObj = this.getNodeObject(nodeId);
+    if (nodeObj !== undefined && nodeObj.componentType !== ComponentType.INPUT)
+      this.computeState(node, nodeObj);
+  },
+  getNodeObject(
+    nodeId: number
+  ): NodeComponent | InputComponent | OutputComponent | undefined {
+    return (
+      Editor.editorEnv.nodes.get(nodeId) ??
+      Editor.editorEnv.inputs.get(nodeId) ??
+      Editor.editorEnv.outputs.get(nodeId)
+    );
+  },
+  computeState(
+    node: SignalGraphData,
+    nodeObj: NodeComponent | InputComponent | OutputComponent
+  ) {
+    const op: (slotState: Array<boolean>) => boolean = nodeObj.nodeType.op;
+    const slotStatus: Array<boolean> = [];
+    for (let i = 0; i < node.signalFrom.length; i++)
+      slotStatus.push(
+        Editor.editorEnv.signalGraph.get(node.signalFrom[i])?.state ?? false
+      );
+    node.state = op(slotStatus);
   },
 };

--- a/src/functions/mouseEvents.ts
+++ b/src/functions/mouseEvents.ts
@@ -8,6 +8,7 @@ import outputEvents from './IO/outputEvents';
 
 import Mouse from '../types/Mouse';
 import EditorEnvironment from '../EditorEnvironment';
+import signalUpdate from './Signal/signalUpdate';
 
 export interface CollisionList {
   [index: string]: Array<number> | undefined;
@@ -85,11 +86,16 @@ export default class MouseEvents {
   onMouseRelease(editorEnv: EditorEnvironment) {
     if (!this._mouse.clicked && this._mouse.stateChanged) {
       if (!this._mouse.dragged) {
-        if (this.collisionList.inputs !== undefined)
+        if (this.collisionList.inputs !== undefined) {
           inputEvents.switchInputState(
             editorEnv.inputs,
             this.collisionList.inputs[0]
           );
+          signalUpdate.updateGraphPartial(
+            editorEnv,
+            this.collisionList.inputs[0]
+          );
+        }
       }
       if (!connectionEvents.fixLine(editorEnv, this._mouse.position)) {
         this.clearDragCollisions();

--- a/src/objects/nodeTypeObjects.ts
+++ b/src/objects/nodeTypeObjects.ts
@@ -99,7 +99,7 @@ const NOTNode: NodeTypeObject = {
     },
   ],
   op(slotState) {
-    return slotState.length >= 1 ? !slotState[0] : false;
+    return slotState.length >= 1 ? !slotState[0] : true;
   },
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -4,6 +4,7 @@ import NodeComponent from '../components/NodeComponent';
 import OutputComponent from '../components/OutputComponent';
 import SlotComponent from '../components/SlotComponent';
 import TextComponent from '../components/TextComponent';
+import Component from '../interfaces/componentInterface';
 import Vector2 from './Vector2';
 
 enum ComponentType {
@@ -56,13 +57,7 @@ export type InputList = Map<number, InputComponent>;
 export type OutputList = Map<number, OutputComponent>;
 
 export interface FullComponentList {
-  [index: string]:
-    | NodeList
-    | SlotList
-    | ConnectionList
-    | TextList
-    | InputList
-    | OutputList;
+  [index: string]: Map<number, Component>;
   nodes: NodeList;
   slots: SlotList;
   connections: ConnectionList;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -109,7 +109,11 @@ export interface OutputTypeObject {
   readonly op: (slotState: Array<boolean>) => boolean;
 }
 
-export type SignalGraphData = {state: boolean; signalFrom: Array<number>};
+export interface SignalGraphData {
+  state: boolean;
+  signalFrom: Array<number>;
+  signalTo: Array<number>;
+}
 
 export type SignalGraph = Map<number, SignalGraphData>;
 


### PR DESCRIPTION
Esse PR adiciona o código necessário para realizar a simulação do comportamento de portas lógicas e componentes de entrada e saída.

O grafo de sinal lógico agora não é direcionado, com cada nó possuindo informações de onde vêm seu sinal e quais nós o recebem.
A mudança foi necessária para diminuir a quantidade de acessos aos componentes em si, na lista principal, já que esse é um processo bem custoso. (Obter nó atual -> Lista de slots -> Encontrar slot requisitado -> Obter conexão -> Obter slot do outro elemento -> Obter nó ao qual se está conectado)

Os dois métodos principais para isso, updateGraph e updateGraphPartial trabalham com o grafo através de algoritmos de DFS.
- O primeiro através de recursão e utilizado quando é necessário atualizar todos os nós do projeto.
- O segundo é utilizado quando os nós anteriores já possuem um estado definido e se deseja atualizar apenas a cadeia de conexões seguinte à atual.

TO-DO:
- [ ] Adicionar testes unitários